### PR TITLE
Set the PHP memory limit to unlimited

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN apk del \
 	build-base \
 ;
 
+# Memory Limit
+RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
+
 # Install composer
 COPY install_composer.sh /root
 RUN /bin/sh /root/install_composer.sh && rm /root/install_composer.sh


### PR DESCRIPTION
Not 100% sure this works (haven't tested it yet) but pretty confident it should work. We set the limit to unlimited since we only use the container for CI jobs, but if people would want to use this for dev as well, we could us a sane default (1024MB should be quite sane)