### PR TITLE
Added bcmath as standard php extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
 
 # Install extensions
 RUN docker-php-ext-install -j $(grep processor /proc/cpuinfo | wc -l) \
+	bcmath \
 	dom \
 	gd \
 	iconv \


### PR DESCRIPTION
Bcmath is needed by a lot of packages that require better floating point precision.